### PR TITLE
Update workflow to sync wasm-bindgen

### DIFF
--- a/.github/typescript-ci-patch.yaml
+++ b/.github/typescript-ci-patch.yaml
@@ -20,7 +20,7 @@
   path: /jobs/test/steps/5
   value:
       name: Compile
-      run: yarn run compile
+      run: cargo update && yarn run compile
 # Coverage doesn't work for this repo
 - op: remove
   path: /jobs/test/steps/7

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -37,6 +37,6 @@ jobs:
     - name: Install modules
       run: yarn
     - name: Compile
-      run: yarn run compile
+      run: cargo update && yarn run compile
     - name: Run tests
       run: yarn run test


### PR DESCRIPTION
The version of wasm-bindgen-cli must match the version of the library -
the library version needs to be updated via `cargo update` to match the
version of wasm-bindgen-cli installed during the build.