### PR TITLE
Make the example app depend on the current version.

### DIFF
--- a/examples/create-react-app-example/package.json
+++ b/examples/create-react-app-example/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "dependencies": {
         "@craco/craco": "^6.4.3",
-        "@ironcorelabs/recrypt-wasm-binding": "^0.6.0",
+        "@ironcorelabs/recrypt-wasm-binding": "^0.6.24-pre",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "5.0.1"


### PR DESCRIPTION
This PR changes the example app to depend on the current version of the library. Once this change is done, automation will ensure they stay in sync: It'll update `version` in the top-level `package.json`, and it'll update `dependencies["@ironcorelabs/recrypt-wasm-binding"]` in the example app. Without this change, it'll throw an error like [this](https://github.com/IronCoreLabs/recrypt-wasm-binding/runs/6309312094?check_suite_focus=true#step:4:7) every time we merge to `main`